### PR TITLE
Fix bug in case time=false is used

### DIFF
--- a/relative_time_plus.jinja
+++ b/relative_time_plus.jinja
@@ -195,7 +195,6 @@
       {%- set week = week | bool(true) -%}
       {%- set time = time | bool(true) -%}
       {%- set abbr = abbr | bool(false) or verbose | bool(false) -%}
-      {%- set date = date if time else date.date() -%}
       {%- set time_parts = time_split(date, compare_date, month, week, time) | from_json -%}
     {#- find first non zero time period #}
       {%- set always_return = 'millisecond' if millisecond else 'second' if time else 'day' -%}


### PR DESCRIPTION
In case `time=false` was used, there would be an error that it's not possible to compare a datetime.date with datetime.datetime.