### PR TITLE
Adding Swedish translations

### DIFF
--- a/relative_time_plus.jinja
+++ b/relative_time_plus.jinja
@@ -133,7 +133,7 @@
                                   }
                                 },
                                 {
-                                  'language': 'se',
+                                  'language': 'sv',
                                   'phrases':
                                   {
                                     'year': ['år', 'år', 'år'],

--- a/relative_time_plus.jinja
+++ b/relative_time_plus.jinja
@@ -131,6 +131,22 @@
                                     'combine': 'og',
                                     'error': 'Ugyldig dato'
                                   }
+                                },
+                                {
+                                  'language': 'se',
+                                  'phrases':
+                                  {
+                                    'year': ['år', 'år', 'år'],
+                                    'month': ['månad', 'månader', 'mån'],
+                                    'week': ['vecka', 'veckor', 'v'],
+                                    'day': ['dag', 'dagar', 'dag'],
+                                    'hour': ['timme', 'timmar', 'tim'],
+                                    'minute': ['minut', 'minuter', 'min'],
+                                    'second': ['sekund', 'sekunder', 'sek'],
+                                    'millisecond': ['millisekund', 'millisekunder', 'ms'],
+                                    'combine': 'och',
+                                    'error': 'Ogiltigt datum'
+                                  }
                                 }
                               ]
 %}


### PR DESCRIPTION
Adding Swedish language translations for future use.
Please be advised that there are some differing opinions regarding the abbreviations. Using 'h' as short for "timme" (from latin "hora") is very common in Swedish too, but I chose "tim", which seems to be consensus among scholars.
Regarding the punctuation mark after the abbreviation, both alternatives seem acceptable. _With_ punctuation mark seems more widely used in flowing texts, and _without_ seems more common when just stating the time. Please feel free to change this to make it fit better with the other translations available.
Also, a squash might be fitting before merge. But I'm leaving that up to the maintainer.